### PR TITLE
Provide two examples that convert xtc1 to xtc2 with just one input file

### DIFF
--- a/examples/zmq_pullall.py
+++ b/examples/zmq_pullall.py
@@ -1,0 +1,164 @@
+"""Receives data from zmq and save in xtc2 format.
+
+Usage:
+    1. Activate psana2 and xtc1to2 environment
+       source lcls2/setup_env.sh
+       export PYTHONPATH=$HOME/xtc1to2/:$PYTHONPATH
+    2. Receive data from zmq
+"""
+from xtc1to2.socket.zmqhelper import ZmqReceiver
+from psana.dgrampy import DgramPy, AlgDef, DetectorDef
+from psana.psexp import TransitionId
+import numpy as np
+import h5py
+from psana import DataSource
+
+
+def test_output():
+    """Compares known data (saved to hdf5 by the push process) with read data."""
+    f = h5py.File('out.hdf5', 'r')
+    pixel_position = f['pixel_position']
+    pixel_index_map = f['pixel_index_map']
+    data = f['data']
+    photon_energy = f['photon_energy']
+
+    ds = DataSource(files='out.xtc2')
+    run = next(ds.runs())
+    det = run.Detector('amopnccd')
+    pp_det = run.Detector('pixel_position')
+    pim_det = run.Detector('pixel_index_map')
+    data_array = np.zeros([3,4,512,512], dtype=np.float32)
+    photon_array = np.zeros(3, dtype=np.float64)
+    for i,evt in enumerate(run.events()):
+        data_array[i,:,:,:] = det.raw.calib(evt)
+        photon_array[i] = det.raw.photon_energy(evt)
+        pixel_position_array = pp_det(evt)
+        pixel_index_map_array = pim_det(evt)
+
+    assert np.array_equal(data,data_array)
+    assert np.array_equal(photon_energy, photon_array)
+    assert np.array_equal(pixel_position, pixel_position_array)
+    assert np.array_equal(pixel_index_map, pixel_index_map_array)
+
+
+
+
+if __name__ == "__main__":
+    flag_test = False
+
+    # NameId setup
+    nodeId = 1 
+    namesId = {
+        "amopnccd": 0,
+        "runinfo": 1,
+        "scan": 2,
+    }
+
+
+    # Setup socket for zmq connection
+    socket = "tcp://127.0.0.1:5558"
+    zmq_recv = ZmqReceiver(socket)
+
+    
+    # Open output file for writing
+    ofname = 'out.xtc2'
+    xtc2file = open(ofname, "wb")
+
+    
+    # Create config, algorithm, and detector
+    config = DgramPy(transition_id=TransitionId.Configure)
+    alg = AlgDef("raw", 1, 2, 3)
+    det = DetectorDef("amopnccd", "pnccd", "detnum1234")
+
+    runinfo_alg = AlgDef("runinfo", 0, 0, 1)
+    runinfo_det = DetectorDef("runinfo", "runinfo", "")
+
+    scan_alg = AlgDef("raw", 2, 0, 0)
+    scan_det = DetectorDef("scan", "scan", "detnum1234")
+
+
+    # Define data formats
+    datadef = {
+        "calib": (np.float32, 3),
+        "photon_energy": (np.float64, 0),
+    }
+
+    runinfodef = {
+        "expt": (str, 1),
+        "runnum": (np.uint32, 0),
+    }
+
+    scandef = {
+        "pixel_position": (np.float64, 4),
+        "pixel_index_map": (np.int64, 4),
+    }
+
+
+    # Create detetors
+    pnccd = config.Detector(det, alg, datadef, nodeId=nodeId, namesId=namesId["amopnccd"])
+    runinfo = config.Detector(runinfo_det, 
+                              runinfo_alg, 
+                              runinfodef, 
+                              nodeId=nodeId, 
+                              namesId=namesId["runinfo"]
+                             )
+    scan = config.Detector(scan_det,
+                           scan_alg,
+                           scandef,
+                           nodeId=nodeId,
+                           namesId=namesId["scan"]
+                          )
+
+
+
+    # Start saving data
+    while True:
+        obj = zmq_recv.recv_zipped_pickle()
+
+        # Begin timestamp is needed (we calculate this from the first L1Accept)
+        # to set the correct timestamp for all transitions prior to the first L1.
+        if "start" in obj:
+            config_timestamp = obj["config_timestamp"]
+            config.updatetimestamp(config_timestamp)
+            config.save(xtc2file)
+
+            beginrun = DgramPy(transition_id=TransitionId.BeginRun, config=config, ts=config_timestamp + 1)
+            runinfo.runinfo.expt = obj["exp"]
+            runinfo.runinfo.runnum = int(obj["run"])
+            beginrun.adddata(runinfo.runinfo)
+            beginrun.save(xtc2file)
+            
+            beginstep = DgramPy(transition_id=TransitionId.BeginStep, config=config, ts=config_timestamp + 2)
+            scan.raw.pixel_position = obj['pixel_position']
+            scan.raw.pixel_index_map = obj['pixel_index_map']
+            beginstep.adddata(scan.raw)
+            beginstep.save(xtc2file)
+            
+            enable = DgramPy(transition_id=TransitionId.Enable, config=config, ts=config_timestamp + 3)
+            enable.save(xtc2file)
+            current_timestamp = config_timestamp + 3
+
+        elif "end" in obj:
+            disable = DgramPy(transition_id=TransitionId.Disable, config=config, ts=current_timestamp + 1)
+            disable.save(xtc2file)
+            endstep = DgramPy(transition_id=TransitionId.EndStep, config=config, ts=current_timestamp + 2)
+            endstep.save(xtc2file)
+            endrun = DgramPy(transition_id=TransitionId.EndRun, config=config, ts=current_timestamp + 3)
+            endrun.save(xtc2file)
+            break
+
+        else:
+            # Create L1Accept
+            d0 = DgramPy(transition_id=TransitionId.L1Accept, config=config, ts=obj["timestamp"])
+            pnccd.raw.calib = obj["calib"]
+            pnccd.raw.photon_energy = obj["photon_energy"]
+            d0.adddata(pnccd.raw)
+            d0.save(xtc2file)
+            current_timestamp = obj["timestamp"]
+
+
+
+    xtc2file.close()
+
+    if flag_test:
+        test_output()

--- a/examples/zmq_pullall.py
+++ b/examples/zmq_pullall.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """Receives data from zmq and save in xtc2 format.
 
 Usage:

--- a/examples/zmq_pushall.py
+++ b/examples/zmq_pushall.py
@@ -18,7 +18,7 @@ import numpy as np
 import csv
 
 
-fl_csv          = "2022_0603_2226_44.auto.label.csv"
+fl_csv     = "2022_0603_2226_44.auto.label.csv"
 label_1hit = '1'
 
 # Specify the dataset and detector...
@@ -41,28 +41,31 @@ img_reader_dict = {}
 phe_reader_dict = {}
 with open(fl_csv) as csv_handle:
     lines = csv.reader(csv_handle)
+
+    # Skip the header...
+    next(lines)
+
+    # Go through each line...
     for line in lines:
-        # Skip the header...
-        next(lines)
+        exp, run, event_num, label = line
 
-        # Go through each line...
-        for line in lines:
-            exp, run, event_num, label = line
+        # Skip if not single hit...
+        if label != label_1hit: continue
 
-            # Specify the key to dictionaries...
-            basename = (exp, run)
+        # Specify the key to dictionaries...
+        basename = (exp, run)
 
-            # Collect run info from each exp,run...
-            if not basename in event_dict: event_dict[basename] = [event_num]
-            else                         : event_dict[basename].append(event_num)
+        # Collect run info from each exp,run...
+        if not basename in event_dict: event_dict[basename] = [event_num]
+        else                         : event_dict[basename].append(event_num)
 
-            # Collect img_reader from each exp,run...
-            if not basename in img_reader_dict: 
-                img_reader_dict[basename] = PsanaImg(exp, run, mode, detector_name)
+        # Collect img_reader from each exp,run...
+        if not basename in img_reader_dict: 
+            img_reader_dict[basename] = PsanaImg(exp, run, mode, detector_name)
 
-            # Collect photon energy from each exp,run...
-            if not basename in phe_reader_dict:
-                phe_reader_dict[basename] = PsanaPhotonEnergy(exp, run, mode)
+        # Collect photon energy from each exp,run...
+        if not basename in phe_reader_dict:
+            phe_reader_dict[basename] = PsanaPhotonEnergy(exp, run, mode)
 
 for i, (basename, event_num_list) in enumerate(event_dict.items()):
     exp, run = basename

--- a/examples/zmq_pushall.py
+++ b/examples/zmq_pushall.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+"""An example that reads in lcls1 experiment and push data to
+be saved in lcls2 format via zmq.
+
+Usage: 
+    1. Get psana1 environment (source /reg/g/psdm/etc/psconda.sh) and 
+    activate py3 env. (conda activate ana-4.0.38-py3)
+    export PYTHONPATH=$HOME/xtc1to2:$PYTHONPATH
+    2. Set exp, run, mode, and detector name
+    3. Set path to geometry file 
+"""
+from xtc1to2.read_img import PsanaImg, DisplaySPIImg
+from xtc1to2.read_photon_energy import PsanaPhotonEnergy
+from xtc1to2.read_geometry import PsanaGeometry
+from xtc1to2.socket.zmqhelper import ZmqSender
+import h5py
+import numpy as np
+import csv
+
+
+fl_csv          = "2022_0603_2226_44.auto.label.csv"
+label_1hit = '1'
+
+# Specify the dataset and detector...
+## exp, run, mode, detector_name = "amo06516", "90", "idx", "pnccdFront"
+geom = (
+    "/reg/d/psdm/amo/amo06516/calib/PNCCD::CalibV1/Camp.0:pnCCD.0/geometry/38-end.data"
+)
+# Initialize the geometry
+gmt_reader = PsanaGeometry(geom)
+
+# Initialize zmq sender
+socket = "tcp://127.0.0.1:5558"
+zmq_send = ZmqSender(socket)
+
+# Collect all items from the auto-labeled file...
+mode            = "idx" 
+detector_name   = "pnccdFront"
+event_dict      = {}
+img_reader_dict = {}
+phe_reader_dict = {}
+with open(fl_csv) as csv_handle:
+    lines = csv.reader(csv_handle)
+    for line in lines:
+        # Skip the header...
+        next(lines)
+
+        # Go through each line...
+        for line in lines:
+            exp, run, event_num, label = line
+
+            # Specify the key to dictionaries...
+            basename = (exp, run)
+
+            # Collect run info from each exp,run...
+            if not basename in event_dict: event_dict[basename] = [event_num]
+            else                         : event_dict[basename].append(event_num)
+
+            # Collect img_reader from each exp,run...
+            if not basename in img_reader_dict: 
+                img_reader_dict[basename] = PsanaImg(exp, run, mode, detector_name)
+
+            # Collect photon energy from each exp,run...
+            if not basename in phe_reader_dict:
+                phe_reader_dict[basename] = PsanaPhotonEnergy(exp, run, mode)
+
+for i, (basename, event_num_list) in enumerate(event_dict.items()):
+    exp, run = basename
+
+    for event_num in event_num_list:
+        ts = img_reader_dict[basename].timestamp(event_num)
+        if i == 0:
+            start_dict = {
+                "exp"             : exp,
+                "run"             : run,
+                "start"           : True,
+                "config_timestamp": ts.time() - 10,
+                "pixel_position"  : gmt_reader.pixel_position,
+                "pixel_index_map" : gmt_reader.pixel_index_map,
+            }
+            zmq_send.send_zipped_pickle(start_dict)
+
+        img = img_reader_dict[basename].get(event_num, calib = True)
+        phe = phe_reader_dict[basename].get(event_num)
+        data = {
+            "calib"        : img,
+            "photon_energy": phe,
+            "timestamp"    : ts.time(),
+        }
+
+        print(
+            f"exp={exp} run={int(run):04d} event_num={int(event_num):06d} ts={ts.time()} img={img.shape} dtype={img.dtype} photon energy:{phe:.3f}"
+        )
+        print(f"pixel_position={gmt_reader.pixel_position.shape} dtype={gmt_reader.pixel_position.dtype}")
+        print(f"pixel_index_map={gmt_reader.pixel_index_map.shape} dtype={gmt_reader.pixel_index_map.dtype}")
+
+        zmq_send.send_zipped_pickle(data)
+
+# Send end message
+done_dict = {"end": True}
+zmq_send.send_zipped_pickle(done_dict)


### PR DESCRIPTION
The input file is a csv file of all labeled events from an automatic labeling program in the hit classifier.  

Part of a csv file is shown below.  Only event with label 1 will be processed.  

```
exp,run,event_num,label
amo06516,90,000591,2
amo06516,90,000709,0
amo06516,90,000795,2
amo06516,90,000796,1
amo06516,90,001313,0
amo06516,90,001371,1
amo06516,90,001501,0
amo06516,90,001694,2
amo06516,90,001789,0
amo06516,90,001997,1
amo06516,90,002281,2
amo06516,90,002453,0
amo06516,90,002496,2
amo06516,90,002631,2
```